### PR TITLE
Implement initial phone extraction architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Pdf-ingester
 
 Este repositorio contiene una prueba de concepto para ingerir archivos PDF, extraer números de teléfono y notificarlos de forma automática. Consulta [docs/ARQUITECTURA.md](docs/ARQUITECTURA.md) para una descripción de la arquitectura propuesta.
+
+## Uso rápido
+
+1. Instala las dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Ejecuta la API con Uvicorn:
+   ```bash
+   uvicorn app:app --reload
+   ```
+
+3. Envía un PDF al endpoint `/ingest` para obtener los teléfonos detectados.
+
+## Pruebas
+
+Ejecuta `pytest` para correr las pruebas unitarias.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI, UploadFile, File
+
+from pdf_ingester.pipeline import process_upload
+
+app = FastAPI(title="PDF Phone Extractor")
+
+
+@app.post("/ingest")
+async def ingest_pdf(file: UploadFile = File(...)):
+    numbers = await process_upload(file)
+    return {"phones": numbers}

--- a/docs/ARQUITECTURA.md
+++ b/docs/ARQUITECTURA.md
@@ -25,3 +25,14 @@ Cada módulo funciona de manera asíncrona para repartir la carga y reintentar f
 - Tiempo promedio de procesamiento por PDF.
 
 La implementación inicial puede concentrarse en la ingesta, extracción de texto y detección básica de teléfonos. Posteriormente se añadirán la validación externa, la mensajería multicanal y un sistema de monitoreo más robusto.
+
+## Implementación de referencia
+
+En esta PoC se incluyó un pequeño servicio basado en **FastAPI** que expone un endpoint `/ingest` para subir un PDF. El flujo de procesamiento se realiza de manera secuencial mediante los siguientes módulos:
+
+- `pdf_ingester.ingestion` guarda el archivo en disco.
+- `pdf_ingester.extraction` utiliza `pdfminer.six` para obtener el texto.
+- `pdf_ingester.phone` detecta y normaliza los números telefónicos mediante `phonenumbers`.
+- `pdf_ingester.pipeline` orquesta los pasos anteriores.
+
+Este código sirve como punto de partida para evolucionar hacia una arquitectura de microservicios con colas de mensajes y procesos asíncronos.

--- a/pdf_ingester/__init__.py
+++ b/pdf_ingester/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities to ingest PDFs and detect phone numbers."""

--- a/pdf_ingester/extraction.py
+++ b/pdf_ingester/extraction.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+from io import StringIO
+from pdfminer.high_level import extract_text
+
+
+def extract_text_from_pdf(pdf_path: Path) -> str:
+    """Return the extracted text from a PDF file."""
+    return extract_text(str(pdf_path))

--- a/pdf_ingester/ingestion.py
+++ b/pdf_ingester/ingestion.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from fastapi import UploadFile
+
+
+def save_pdf(file: UploadFile, directory: Path = Path("uploads")) -> Path:
+    """Save uploaded PDF to disk and return the saved path."""
+    directory.mkdir(parents=True, exist_ok=True)
+    file_path = directory / file.filename
+    with file_path.open("wb") as f:
+        f.write(file.file.read())
+    return file_path

--- a/pdf_ingester/phone.py
+++ b/pdf_ingester/phone.py
@@ -1,0 +1,18 @@
+import re
+from typing import List
+import phonenumbers
+
+PHONE_REGEX = re.compile(r"\+?\d[\d\s()-]{7,}\d")
+
+
+def find_phone_numbers(text: str, region: str = "AR") -> List[str]:
+    """Find and normalize phone numbers in given text."""
+    numbers = []
+    for match in PHONE_REGEX.findall(text):
+        try:
+            parsed = phonenumbers.parse(match, region)
+            if phonenumbers.is_valid_number(parsed):
+                numbers.append(phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164))
+        except phonenumbers.NumberParseException:
+            continue
+    return numbers

--- a/pdf_ingester/pipeline.py
+++ b/pdf_ingester/pipeline.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from fastapi import UploadFile
+
+from .ingestion import save_pdf
+from .extraction import extract_text_from_pdf
+from .phone import find_phone_numbers
+
+
+async def process_upload(file: UploadFile) -> list[str]:
+    """Save PDF, extract text and return phone numbers found."""
+    pdf_path = save_pdf(file)
+    text = extract_text_from_pdf(pdf_path)
+    return find_phone_numbers(text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pdfminer.six
+phonenumbers

--- a/tests/test_phone.py
+++ b/tests/test_phone.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from pdf_ingester.phone import find_phone_numbers
+
+
+def test_find_phone_numbers():
+    text = "Contacto: +54 11 1234-5678 y 011 4321-8765"
+    numbers = find_phone_numbers(text, region="AR")
+    assert "+541112345678" in numbers
+    assert "+541143218765" in numbers


### PR DESCRIPTION
## Summary
- create FastAPI app with `/ingest` endpoint
- save uploaded PDFs, extract text and find phone numbers
- document running instructions and add requirements
- describe reference implementation in architecture doc
- add unit test for phone detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686bf07ef54c8330adf2edf531728549